### PR TITLE
Use union merge strategy for CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
This will reduce conflicts in the CHANGELOG. Bad merges are unlikely.

See the "Update" section here:
https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/

## Checklist

- [x] Tests added if applicable
- [x] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
