### PR TITLE
Add basic support for v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Possible log types:
 
 - [added] The `Sensors`, `PeopleNowPresentSensor` and `TemperatureSensor`
   structs now derive `Default` (#84)
+- [added] Basic support for the new v14 API (#85) This is a breaking change since
+  it changes the `api` field of `Status` to `Option<String>`.
 
 ### v0.7.0 (2019-08-22)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/spaceapi.svg)](https://crates.io/crates/spaceapi)
 [![Crates.io Downloads](https://img.shields.io/crates/d/spaceapi.svg)](https://crates.io/crates/spaceapi)
 
-This is an implementation of the [SpaceAPI](https://spaceapi.io/) v0.13
+This is an implementation of the [SpaceAPI](https://spaceapi.io/) v0.13 and v14
 in Rust. It contains both the type definitions as well as tools for
 serialization and deserialization to/from JSON using Serde.
 
@@ -19,7 +19,7 @@ This library requires Rust 1.31.0 or newer.
 Add `spaceapi` to your `Cargo.toml`:
 
     [dependencies]
-    spaceapi = "^0.5"
+    spaceapi = "^0.7"
 
 
 ## Docs

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -3,7 +3,7 @@ use serde_json;
 use spaceapi::{Contact, IssueReportChannel, Location, StatusBuilder};
 
 fn main() {
-    let status = StatusBuilder::new("coredump")
+    let status = StatusBuilder::mixed("coredump")
         .logo("https://www.coredump.ch/logo.png")
         .url("https://www.coredump.ch/")
         .location(Location {

--- a/src/status.rs
+++ b/src/status.rs
@@ -157,12 +157,21 @@ pub struct Stream {
     pub ustream: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ApiVersion {
+    #[serde(rename = "14")]
+    V14,
+}
+
 /// The main SpaceAPI status object.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct Status {
     // Hackerspace properties
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_compatibility: Option<Vec<ApiVersion>>,
 
     pub space: String,
     pub logo: String,

--- a/src/status.rs
+++ b/src/status.rs
@@ -435,6 +435,54 @@ mod test {
     }
 
     #[test]
+    fn test_builder_v14() {
+        let status = StatusBuilder::v14("foo")
+            .logo("bar")
+            .url("foobar")
+            .location(Location::default())
+            .contact(Contact::default())
+            .add_issue_report_channel(IssueReportChannel::Email)
+            .build()
+            .unwrap();
+        assert_eq!(
+            status,
+            Status {
+                api: None,
+                api_compatibility: Some(vec![ApiVersion::V14]),
+                space: "foo".into(),
+                logo: "bar".into(),
+                url: "foobar".into(),
+                issue_report_channels: vec![IssueReportChannel::Email],
+                ..Status::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_builder_mixed() {
+        let status = StatusBuilder::mixed("foo")
+            .logo("bar")
+            .url("foobar")
+            .location(Location::default())
+            .contact(Contact::default())
+            .add_issue_report_channel(IssueReportChannel::Email)
+            .build()
+            .unwrap();
+        assert_eq!(
+            status,
+            Status {
+                api: Some("0.13".into()),
+                api_compatibility: Some(vec![ApiVersion::V14]),
+                space: "foo".into(),
+                logo: "bar".into(),
+                url: "foobar".into(),
+                issue_report_channels: vec![IssueReportChannel::Email],
+                ..Status::default()
+            }
+        );
+    }
+
+    #[test]
     fn test_builder() {
         let status = StatusBuilder::new("foo")
             .logo("bar")

--- a/src/status.rs
+++ b/src/status.rs
@@ -161,7 +161,9 @@ pub struct Stream {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct Status {
     // Hackerspace properties
-    pub api: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api: Option<String>,
+
     pub space: String,
     pub logo: String,
     pub url: String,
@@ -214,7 +216,7 @@ impl Status {
         issue_report_channels: Vec<IssueReportChannel>,
     ) -> Status {
         Status {
-            api: "0.13".into(),
+            api: Some("0.13".into()),
             space: space.into(),
             logo: logo.into(),
             url: url.into(),
@@ -321,7 +323,7 @@ impl StatusBuilder {
 
     pub fn build(self) -> Result<Status, String> {
         Ok(Status {
-            api: "0.13".into(), // TODO: Deduplicate
+            api: Some("0.13".into()), // TODO: Deduplicate
             space: self.space,
             logo: self.logo.ok_or("logo missing")?,
             url: self.url.ok_or("url missing")?,
@@ -392,7 +394,7 @@ mod test {
             .add_issue_report_channel(IssueReportChannel::Email)
             .build()
             .unwrap();
-        assert_eq!(status.api, "0.13");
+        assert_eq!(status.api, Some("0.13".into()));
         assert_eq!(status.space, "foo");
         assert_eq!(status.logo, "bar");
         assert_eq!(status.url, "foobar");
@@ -525,7 +527,7 @@ mod test {
                     \"location\":{\"lat\":0.0,\"lon\":0.0},\"contact\":{},\"issue_report_channels\":[],\
                     \"state\":{\"open\":null},\"ext_aaa\":\"xxx\",\"ext_bbb\":[null,42]}";
         let deserialized: Status = from_str(&data).unwrap();
-        assert_eq!(&deserialized.api, "0.13");
+        assert_eq!(deserialized.api, Some("0.13".into()));
         let keys: Vec<_> = deserialized.extensions.keys().collect();
         assert_eq!(keys.len(), 2)
     }


### PR DESCRIPTION
<!--- Explain your issue / bug / feature -->
So the goal is to have an implementation which can serialize and deserialize v0.13, v14 and mixed implementations which provides compatibility for both. This means we need to make fields optional which were removed in v14 or were not present in v0.13.

## Checklist

- [x] Tests added if applicable
- [x] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
