### PR TITLE
v14: Make state field optional and disallow null for state.open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Possible log types:
 
 - [added] The `Sensors`, `PeopleNowPresentSensor` and `TemperatureSensor`
   structs now derive `Default` (#84)
-- [added] Basic support for the new v14 API (#85) This is a breaking change since
-  it changes the `api` field of `Status` to `Option<String>`. Includes
+- [added] Basic support for the new v14 API (#85, #87, #89, #90, #91) This is a
+  breaking change since it changes the `api` field of `Status` to
+  `Option<String>` and the `state` field to `Option<State>`. Includes
   * Add `xmpp` field in `Contact` struct and deprecate the `jabber` field
   * Add `xmpp` field to `Keymaster`
   * Rename jabber to xmpp in contact field
@@ -25,6 +26,7 @@ Possible log types:
     spacefed.spacephone and stream keys
   * Add `mumble`, `matrix`, `mastodon` and `gopher` to `Contact`
   * Add `mastodon` field to `Keymaster`
+  * Make `state` field optional and disallow `null` for `state.open`
 
 
 ### v0.7.0 (2019-08-22)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,16 @@
 //! You can create a new `Status` instance by using the `StatusBuilder`.
 //!
 //!     use serde_json;
-//!     use spaceapi::{Status, StatusBuilder, Location, Contact, IssueReportChannel};
+//!     use spaceapi::{State, Status, StatusBuilder, Location, Contact, IssueReportChannel};
 //!
 //!     # fn main() {
 //!     let status = StatusBuilder::new("coredump")
 //!         .logo("https://www.coredump.ch/logo.png")
 //!         .url("https://www.coredump.ch/")
+//!         .state(State{
+//!             open: Some(false),
+//!             ..State::default()
+//!         })
 //!         .location(
 //!             Location {
 //!                 address: None,


### PR DESCRIPTION
In v0.13 state and but state.open must be present, but state.open may be
null. This doesn't provide any benefit, so v14 removed these
restrictions.

We can't provide full backwards compatiblity, since state.open == null
is not supported in v14.

To still have a json which is compatible with both v0.13 and v14
state.open must be set to either true or false.

<!--- Explain your issue / bug / feature -->

## Checklist

- [x] Tests added if applicable
- [na] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
