### PR TITLE
Bump MSRV to 1.36.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   test:
     docker:
-      - image: rust:1.31
+      - image: rust:1.36
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ serialization and deserialization to/from JSON using Serde.
 - Crate Documentation: https://docs.rs/spaceapi/
 - SpaceAPI Documentation: https://spaceapi.io/pages/docs.html
 
-This library requires Rust 1.31.0 or newer.
+This library requires Rust 1.36.0 or newer.
 
 
 ## Usage


### PR DESCRIPTION
A dependency started to use MaybeUninit which needs at least Rust 1.36.0

<!--- Explain your issue / bug / feature -->

## Checklist

- [na] Tests added if applicable
- [X] README updated if applicable
- [na] CHANGELOG updated if applicable
- [na] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
