### PR TITLE
Additional v14 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Possible log types:
 - [added] Added the `HumitidySensor` and `PowerConsumptionSensor` sensor types.
 - [added] Added the `timezone` key under `location` section.
 - [added] Added the `links` section.
+- [added] Added the `membership_plans` section.
 
 ### v0.8.1 (2021-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Possible log types:
 
 - [added] Added the `HumitidySensor` and `PowerConsumptionSensor` sensor types.
 - [added] Added the `timezone` key under `location` section.
+- [added] Added the `links` section.
 
 ### v0.8.1 (2021-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ### Unreleased
 
 - [added] Added the `HumitidySensor` and `PowerConsumptionSensor` sensor types.
+- [added] Added the `timezone` key under `location` section.
 
 ### v0.8.1 (2021-07-06)
 

--- a/examples/serialization.rs
+++ b/examples/serialization.rs
@@ -8,6 +8,7 @@ fn main() {
             address: None,
             lat: 47.22936,
             lon: 8.82949,
+            ..Default::default()
         })
         .contact(Contact {
             irc: Some("irc://freenode.net/#coredump".into()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //!                 address: None,
 //!                 lat: 47.22936,
 //!                 lon: 8.82949,
+//!                 ..Default::default()
 //!             })
 //!         .contact(
 //!             Contact {
@@ -71,7 +72,7 @@
 //!     println!("{:?}", decoded);
 //!
 //!     // Output:
-//!     // Location { address: None, lat: 47.22936000000001, lon: 8.829490000000002 }
+//!     // Location { address: None, lat: 47.22936000000001, lon: 8.829490000000002, timezone: None }
 //!     # }
 
 pub mod sensors;


### PR DESCRIPTION
Adds the following v14 features:

- `location.timezone`
- `links`
- `membership_plans`

## Checklist

- [x] Tests added if applicable
- [ ] README updated if applicable
- [x] CHANGELOG updated if applicable
- [ ] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
