### PR TITLE
Remove on_push workflow filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,11 @@ jobs:
 workflows:
   version: 2
 
-  # Build on push
-  on_push:
-    jobs:
-      - test
-      - lint
-      - fmt
-      - audit
+  jobs:
+    - test
+    - lint
+    - fmt
+    - audit
 
   # Build master every week on Monday at 04:00 am
   weekly:


### PR DESCRIPTION
I can't find the `on_push` filter anywhere in the documentation of CircleCI https://circleci.com/docs/configuration-reference#workflows.

Also I suspect that it is the reason that external pull requests don't trigger a build.

<!--- Explain your issue / bug / feature -->

## Checklist

- [ ] Tests added if applicable
- [ ] README updated if applicable
- [ ] CHANGELOG updated if applicable
- [ ] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
