### PR TITLE
Tidy sensor re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Possible log types:
 
 ### Unreleased
 
+- [changed] Changed the way sensor types are exported.
+  Some sensor types that were previously exported in the `spaceapi` module now need to be imported from the `spaceapi::sensors` module.
 - [changed] Rewrite parts of the sensor implementation.
   This is a breaking change as it changes the way sensor templates are constructed for `PeopleNowPresentSensor` and `TemperatureSensor`.
 - [added] Added the `HumitidySensor` and `PowerConsumptionSensor` sensor types.

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,10 +3,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 
-pub use crate::sensors::PeopleNowPresentSensor;
-pub use crate::sensors::SensorTemplate;
-pub use crate::sensors::Sensors;
-pub use crate::sensors::TemperatureSensor;
+use crate::sensors::Sensors;
 
 type Extensions = BTreeMap<String, Value>;
 


### PR DESCRIPTION
- Do not re-export sensors in the `status` module

## Checklist

- [ ] Tests added if applicable
- [ ] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
