### PR TITLE
Add remaining sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Possible log types:
 - [changed] Changed the way sensor types are exported.
   Some sensor types that were previously exported in the `spaceapi` module now need to be imported from the `spaceapi::sensors` module.
 - [changed] The `names` field is no longer part of `PeopleNowPresentSensor`.
+- [added] Added all missing sensor types.
 - [changed] Rewrite parts of the sensor implementation.
   This is a breaking change as it changes the way sensor templates are constructed for `PeopleNowPresentSensor` and `TemperatureSensor`.
 - [added] Added the `HumitidySensor` and `PowerConsumptionSensor` sensor types.

--- a/src/sensors/account_balance.rs
+++ b/src/sensors/account_balance.rs
@@ -1,0 +1,37 @@
+//! Module providing account balance sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadata, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct AccountBalanceSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    pub unit: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AccountBalanceSensorTemplate {
+    pub metadata: SensorMetadata,
+    pub unit: String,
+}
+
+impl FromSensorTemplate<AccountBalanceSensorTemplate> for AccountBalanceSensor {
+    fn try_from(template: &AccountBalanceSensorTemplate, value: &str) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            unit: template.unit.clone(),
+            value: value.parse()?,
+        })
+    }
+}
+
+impl SensorTemplate for AccountBalanceSensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .account_balance
+            .push(AccountBalanceSensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/barometer.rs
+++ b/src/sensors/barometer.rs
@@ -1,0 +1,37 @@
+//! Module providing barometer sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadataWithLocation, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct BarometerSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadataWithLocation,
+    pub unit: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BarometerSensorTemplate {
+    pub metadata: SensorMetadataWithLocation,
+    pub unit: String,
+}
+
+impl FromSensorTemplate<BarometerSensorTemplate> for BarometerSensor {
+    fn try_from(template: &BarometerSensorTemplate, value: &str) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            unit: template.unit.clone(),
+            value: value.parse()?,
+        })
+    }
+}
+
+impl SensorTemplate for BarometerSensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .barometer
+            .push(BarometerSensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/beverage_supply.rs
+++ b/src/sensors/beverage_supply.rs
@@ -1,0 +1,37 @@
+//! Module providing beverage supply sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadata, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+pub struct BeverageSupplySensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    pub unit: String,
+    pub value: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BeverageSupplySensorTemplate {
+    pub metadata: SensorMetadata,
+    pub unit: String,
+}
+
+impl FromSensorTemplate<BeverageSupplySensorTemplate> for BeverageSupplySensor {
+    fn try_from(template: &BeverageSupplySensorTemplate, value: &str) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            unit: template.unit.clone(),
+            value: value.parse()?,
+        })
+    }
+}
+
+impl SensorTemplate for BeverageSupplySensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .beverage_supply
+            .push(BeverageSupplySensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/door_locked.rs
+++ b/src/sensors/door_locked.rs
@@ -1,0 +1,34 @@
+//! Module providing door lock sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadataWithLocation, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+pub struct DoorLockedSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadataWithLocation,
+    pub value: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DoorLockedSensorTemplate {
+    pub metadata: SensorMetadataWithLocation,
+}
+
+impl FromSensorTemplate<DoorLockedSensorTemplate> for DoorLockedSensor {
+    fn try_from(template: &DoorLockedSensorTemplate, value: &str) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            value: value.parse()?,
+        })
+    }
+}
+
+impl SensorTemplate for DoorLockedSensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .door_locked
+            .push(DoorLockedSensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -1,5 +1,6 @@
 //! Module defining common sensor functionality.
 
+mod account_balance;
 mod barometer;
 mod beverage_supply;
 mod door_locked;
@@ -10,6 +11,7 @@ mod temperature;
 mod total_member_count;
 mod wind;
 
+pub use account_balance::{AccountBalanceSensor, AccountBalanceSensorTemplate};
 pub use barometer::{BarometerSensor, BarometerSensorTemplate};
 pub use beverage_supply::{BeverageSupplySensor, BeverageSupplySensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
@@ -103,6 +105,8 @@ pub struct Sensors {
     pub wind: Vec<WindSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub beverage_supply: Vec<BeverageSupplySensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub account_balance: Vec<AccountBalanceSensor>,
 }
 
 #[cfg(test)]
@@ -122,6 +126,7 @@ mod test {
             total_member_count: vec![],
             wind: vec![],
             beverage_supply: vec![],
+            account_balance: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -9,6 +9,7 @@ mod network_connections;
 mod network_traffic;
 mod people_now_present;
 mod power_consumption;
+mod radiation;
 mod temperature;
 mod total_member_count;
 mod wind;
@@ -28,6 +29,7 @@ pub use network_traffic::{
 };
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
+pub use radiation::{RadiationSensor, RadiationSensorUnit, RadiationSensors};
 pub use temperature::{TemperatureSensor, TemperatureSensorTemplate};
 pub use total_member_count::{TotalMemberCountSensor, TotalMemberCountSensorTemplate};
 pub use wind::{WindSensor, WindSensorMeasurement, WindSensorProperties};
@@ -121,6 +123,8 @@ pub struct Sensors {
     pub network_connections: Vec<NetworkConnectionsSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub network_traffic: Vec<NetworkTrafficSensor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub radiation: Option<RadiationSensors>,
 }
 
 #[cfg(test)]
@@ -143,6 +147,7 @@ mod test {
             account_balance: vec![],
             network_connections: vec![],
             network_traffic: vec![],
+            radiation: None,
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -1,6 +1,7 @@
 //! Module defining common sensor functionality.
 
 mod barometer;
+mod beverage_supply;
 mod door_locked;
 mod humidity;
 mod people_now_present;
@@ -10,6 +11,7 @@ mod total_member_count;
 mod wind;
 
 pub use barometer::{BarometerSensor, BarometerSensorTemplate};
+pub use beverage_supply::{BeverageSupplySensor, BeverageSupplySensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
 pub use humidity::{HumiditySensor, HumiditySensorTemplate};
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
@@ -99,6 +101,8 @@ pub struct Sensors {
     pub total_member_count: Vec<TotalMemberCountSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub wind: Vec<WindSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub beverage_supply: Vec<BeverageSupplySensor>,
 }
 
 #[cfg(test)]
@@ -117,6 +121,7 @@ mod test {
             barometer: vec![],
             total_member_count: vec![],
             wind: vec![],
+            beverage_supply: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -1,11 +1,13 @@
 //! Module defining common sensor functionality.
 
+mod barometer;
+mod door_locked;
 mod humidity;
 mod people_now_present;
-mod door_locked;
 mod power_consumption;
 mod temperature;
 
+pub use barometer::{BarometerSensor, BarometerSensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
 pub use humidity::{HumiditySensor, HumiditySensorTemplate};
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
@@ -87,6 +89,8 @@ pub struct Sensors {
     pub power_consumption: Vec<PowerConsumptionSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub door_locked: Vec<DoorLockedSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub barometer: Vec<BarometerSensor>,
 }
 
 #[cfg(test)]
@@ -102,6 +106,7 @@ mod test {
             humidity: vec![],
             power_consumption: vec![],
             door_locked: vec![],
+            barometer: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -7,6 +7,7 @@ mod people_now_present;
 mod power_consumption;
 mod temperature;
 mod total_member_count;
+mod wind;
 
 pub use barometer::{BarometerSensor, BarometerSensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
@@ -15,6 +16,7 @@ pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTempl
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
 pub use temperature::{TemperatureSensor, TemperatureSensorTemplate};
 pub use total_member_count::{TotalMemberCountSensor, TotalMemberCountSensorTemplate};
+pub use wind::{WindSensor, WindSensorMeasurement, WindSensorProperties};
 
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -95,6 +97,8 @@ pub struct Sensors {
     pub barometer: Vec<BarometerSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub total_member_count: Vec<TotalMemberCountSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wind: Vec<WindSensor>,
 }
 
 #[cfg(test)]
@@ -112,6 +116,7 @@ mod test {
             door_locked: vec![],
             barometer: vec![],
             total_member_count: vec![],
+            wind: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -2,9 +2,11 @@
 
 mod humidity;
 mod people_now_present;
+mod door_locked;
 mod power_consumption;
 mod temperature;
 
+pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
 pub use humidity::{HumiditySensor, HumiditySensorTemplate};
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
@@ -45,6 +47,10 @@ pub enum SensorTemplateError {
     /// Failed when parsing a floating point value from the provided value string
     #[error("sensor float value cannot be parsed")]
     BadFloat(#[from] std::num::ParseFloatError),
+
+    /// Failed when parsing a boolean value from the provided value string
+    #[error("sensor boolean value cannot be parsed")]
+    BadBool(#[from] std::str::ParseBoolError),
 }
 
 /// Trait that allows sensors to be created from a template and string value.
@@ -79,6 +85,8 @@ pub struct Sensors {
     pub humidity: Vec<HumiditySensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub power_consumption: Vec<PowerConsumptionSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub door_locked: Vec<DoorLockedSensor>,
 }
 
 #[cfg(test)]
@@ -93,6 +101,7 @@ mod test {
             temperature: vec![],
             humidity: vec![],
             power_consumption: vec![],
+            door_locked: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -6,6 +6,7 @@ mod beverage_supply;
 mod door_locked;
 mod humidity;
 mod network_connections;
+mod network_traffic;
 mod people_now_present;
 mod power_consumption;
 mod temperature;
@@ -20,6 +21,10 @@ pub use humidity::{HumiditySensor, HumiditySensorTemplate};
 pub use network_connections::{
     NetworkConnectionKind, NetworkConnectionMachine, NetworkConnectionsSensor,
     NetworkConnectionsSensorTemplate,
+};
+pub use network_traffic::{
+    NetworkTrafficBitsPerSecond, NetworkTrafficPacketsPerSecond, NetworkTrafficSensor,
+    NetworkTrafficSensorProperties,
 };
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
@@ -114,6 +119,8 @@ pub struct Sensors {
     pub account_balance: Vec<AccountBalanceSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub network_connections: Vec<NetworkConnectionsSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub network_traffic: Vec<NetworkTrafficSensor>,
 }
 
 #[cfg(test)]
@@ -135,6 +142,7 @@ mod test {
             beverage_supply: vec![],
             account_balance: vec![],
             network_connections: vec![],
+            network_traffic: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -5,6 +5,7 @@ mod barometer;
 mod beverage_supply;
 mod door_locked;
 mod humidity;
+mod network_connections;
 mod people_now_present;
 mod power_consumption;
 mod temperature;
@@ -16,6 +17,10 @@ pub use barometer::{BarometerSensor, BarometerSensorTemplate};
 pub use beverage_supply::{BeverageSupplySensor, BeverageSupplySensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
 pub use humidity::{HumiditySensor, HumiditySensorTemplate};
+pub use network_connections::{
+    NetworkConnectionKind, NetworkConnectionMachine, NetworkConnectionsSensor,
+    NetworkConnectionsSensorTemplate,
+};
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
 pub use temperature::{TemperatureSensor, TemperatureSensorTemplate};
@@ -107,6 +112,8 @@ pub struct Sensors {
     pub beverage_supply: Vec<BeverageSupplySensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub account_balance: Vec<AccountBalanceSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub network_connections: Vec<NetworkConnectionsSensor>,
 }
 
 #[cfg(test)]
@@ -127,6 +134,7 @@ mod test {
             wind: vec![],
             beverage_supply: vec![],
             account_balance: vec![],
+            network_connections: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -6,6 +6,7 @@ mod humidity;
 mod people_now_present;
 mod power_consumption;
 mod temperature;
+mod total_member_count;
 
 pub use barometer::{BarometerSensor, BarometerSensorTemplate};
 pub use door_locked::{DoorLockedSensor, DoorLockedSensorTemplate};
@@ -13,6 +14,7 @@ pub use humidity::{HumiditySensor, HumiditySensorTemplate};
 pub use people_now_present::{PeopleNowPresentSensor, PeopleNowPresentSensorTemplate};
 pub use power_consumption::{PowerConsumptionSensor, PowerConsumptionSensorTemplate};
 pub use temperature::{TemperatureSensor, TemperatureSensorTemplate};
+pub use total_member_count::{TotalMemberCountSensor, TotalMemberCountSensorTemplate};
 
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -91,6 +93,8 @@ pub struct Sensors {
     pub door_locked: Vec<DoorLockedSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub barometer: Vec<BarometerSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub total_member_count: Vec<TotalMemberCountSensor>,
 }
 
 #[cfg(test)]
@@ -107,6 +111,7 @@ mod test {
             power_consumption: vec![],
             door_locked: vec![],
             barometer: vec![],
+            total_member_count: vec![],
         };
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -100,31 +100,31 @@ pub trait SensorTemplate: Send + Sync {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct Sensors {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub people_now_present: Vec<PeopleNowPresentSensor>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub temperature: Vec<TemperatureSensor>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub humidity: Vec<HumiditySensor>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub power_consumption: Vec<PowerConsumptionSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub door_locked: Vec<DoorLockedSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub barometer: Vec<BarometerSensor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub radiation: Option<RadiationSensors>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub total_member_count: Vec<TotalMemberCountSensor>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub wind: Vec<WindSensor>,
+    pub humidity: Vec<HumiditySensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub beverage_supply: Vec<BeverageSupplySensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub account_balance: Vec<AccountBalanceSensor>,
+    pub power_consumption: Vec<PowerConsumptionSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wind: Vec<WindSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub network_connections: Vec<NetworkConnectionsSensor>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub account_balance: Vec<AccountBalanceSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub total_member_count: Vec<TotalMemberCountSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub people_now_present: Vec<PeopleNowPresentSensor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub network_traffic: Vec<NetworkTrafficSensor>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub radiation: Option<RadiationSensors>,
 }
 
 #[cfg(test)]
@@ -134,21 +134,7 @@ mod test {
 
     #[test]
     fn serialize_deserialize_sensors() {
-        let a = Sensors {
-            people_now_present: vec![],
-            temperature: vec![],
-            humidity: vec![],
-            power_consumption: vec![],
-            door_locked: vec![],
-            barometer: vec![],
-            total_member_count: vec![],
-            wind: vec![],
-            beverage_supply: vec![],
-            account_balance: vec![],
-            network_connections: vec![],
-            network_traffic: vec![],
-            radiation: None,
-        };
+        let a = Sensors::default();
         let b: Sensors = from_str(&to_string(&a).unwrap()).unwrap();
         assert_eq!(a, b);
     }

--- a/src/sensors/network_connections.rs
+++ b/src/sensors/network_connections.rs
@@ -1,0 +1,59 @@
+//! Module providing network connections sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadata, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+pub struct NetworkConnectionsSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machines: Option<Vec<NetworkConnectionMachine>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub kind: Option<NetworkConnectionKind>,
+    pub value: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkConnectionKind {
+    Wifi,
+    Cable,
+    Spacenet,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+pub struct NetworkConnectionMachine {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub mac: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NetworkConnectionsSensorTemplate {
+    pub metadata: SensorMetadata,
+    pub kind: Option<NetworkConnectionKind>,
+}
+
+impl FromSensorTemplate<NetworkConnectionsSensorTemplate> for NetworkConnectionsSensor {
+    fn try_from(
+        template: &NetworkConnectionsSensorTemplate,
+        value: &str,
+    ) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            kind: template.kind.clone(),
+            value: value.parse()?,
+            ..Default::default()
+        })
+    }
+}
+
+impl SensorTemplate for NetworkConnectionsSensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .network_connections
+            .push(NetworkConnectionsSensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/network_traffic.rs
+++ b/src/sensors/network_traffic.rs
@@ -1,0 +1,55 @@
+//! Module providing network traffic sensor functionality.
+
+use super::SensorMetadata;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct NetworkTrafficSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    pub properties: NetworkTrafficSensorProperties,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct NetworkTrafficSensorProperties {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bits_per_second: Option<NetworkTrafficBitsPerSecond>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packets_per_second: Option<NetworkTrafficPacketsPerSecond>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct NetworkTrafficBitsPerSecond {
+    pub value: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<f64>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct NetworkTrafficPacketsPerSecond {
+    pub value: f64,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let sensor = NetworkTrafficSensor {
+            properties: NetworkTrafficSensorProperties {
+                bits_per_second: Some(NetworkTrafficBitsPerSecond {
+                    value: 42.0,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(
+            "{\"properties\":{\"bits_per_second\":{\"value\":42.0}}}",
+            serde_json::to_string(&sensor).unwrap()
+        );
+    }
+}

--- a/src/sensors/radiation.rs
+++ b/src/sensors/radiation.rs
@@ -1,0 +1,66 @@
+//! Module providing radiation sensor functionality.
+
+use super::SensorMetadata;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct RadiationSensors {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha: Option<Vec<RadiationSensor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beta: Option<Vec<RadiationSensor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gamma: Option<Vec<RadiationSensor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beta_gamma: Option<Vec<RadiationSensor>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RadiationSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dead_time: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversion_factor: Option<f64>,
+    pub unit: RadiationSensorUnit,
+    pub value: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum RadiationSensorUnit {
+    #[serde(rename = "cpm")]
+    CountsPerMinute,
+    #[serde(rename = "r/h")]
+    RadsPerHour,
+    #[serde(rename = "µSv/h")]
+    MicroSievertsPerHour,
+    #[serde(rename = "µSv/a")]
+    MicroSievertsPerYear,
+    #[serde(rename = "mSv/h")]
+    MilliSievertsPerYear,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let sensors = RadiationSensors {
+            alpha: Some(vec![RadiationSensor {
+                metadata: Default::default(),
+                dead_time: None,
+                conversion_factor: None,
+                unit: RadiationSensorUnit::MicroSievertsPerHour,
+                value: 0.15,
+            }]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            "{\"alpha\":[{\"unit\":\"µSv/h\",\"value\":0.15}]}",
+            serde_json::to_string(&sensors).unwrap()
+        );
+    }
+}

--- a/src/sensors/total_member_count.rs
+++ b/src/sensors/total_member_count.rs
@@ -1,0 +1,34 @@
+//! Module providing total member count sensor functionality.
+
+use super::{FromSensorTemplate, SensorMetadata, SensorTemplate, SensorTemplateError, Sensors};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+pub struct TotalMemberCountSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadata,
+    pub value: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct TotalMemberCountSensorTemplate {
+    pub metadata: SensorMetadata,
+}
+
+impl FromSensorTemplate<TotalMemberCountSensorTemplate> for TotalMemberCountSensor {
+    fn try_from(template: &TotalMemberCountSensorTemplate, value: &str) -> Result<Self, SensorTemplateError> {
+        Ok(Self {
+            metadata: template.metadata.clone(),
+            value: value.parse()?,
+        })
+    }
+}
+
+impl SensorTemplate for TotalMemberCountSensorTemplate {
+    fn try_to_sensor(&self, value_str: &str, sensors: &mut Sensors) -> Result<(), SensorTemplateError> {
+        sensors
+            .total_member_count
+            .push(TotalMemberCountSensor::try_from(self, value_str)?);
+        Ok(())
+    }
+}

--- a/src/sensors/wind.rs
+++ b/src/sensors/wind.rs
@@ -1,0 +1,37 @@
+//! Module providing wind sensor functionality.
+
+use super::SensorMetadataWithLocation;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct WindSensor {
+    #[serde(flatten)]
+    pub metadata: SensorMetadataWithLocation,
+    pub properties: WindSensorProperties,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct WindSensorProperties {
+    pub speed: WindSensorMeasurement,
+    pub gust: WindSensorMeasurement,
+    pub direction: WindSensorMeasurement,
+    pub elevation: WindSensorMeasurement,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct WindSensorMeasurement {
+    pub unit: String,
+    pub value: f64,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let sensor = WindSensor::default();
+
+        assert_eq!("{\"location\":\"\",\"properties\":{\"speed\":{\"unit\":\"\",\"value\":0.0},\"gust\":{\"unit\":\"\",\"value\":0.0},\"direction\":{\"unit\":\"\",\"value\":0.0},\"elevation\":{\"unit\":\"\",\"value\":0.0}}}", serde_json::to_string(&sensor).unwrap());
+    }
+}


### PR DESCRIPTION
Adds remaining missing sensors.

For some of the non-trivial sensors (e.g. wind and radiation) the template pattern (of updating with a single value) does not fit well in the current form so such sensors only have the types required for serialization and deserialization.

Fixes #3.

## Checklist

- [x] Tests added if applicable
- [ ] README updated if applicable
- [x] CHANGELOG updated if applicable
- [ ] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
