### PR TITLE
Fix name of "state.icon.closed" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Possible log types:
 - [added] Added the `links` section.
 - [added] Added the `membership_plans` section.
 - [added] Derive `Eq` as well and not just `PartialEq` where possible.
+- [fixed] The name for the "closed icon" field has been corrected to `state.icon.closed` (was `state.icon.close`).
 
 ### v0.8.1 (2021-07-06)
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -935,7 +935,11 @@ mod test {
             "contact": {},
             "issue_report_channels": [],
             "state": {
-                "open": null
+                "open": null,
+                "icon": {
+                    "open": "d",
+                    "closed": "e"
+                }
             },
             "ext_aaa": "xxx",
             "ext_bbb": [null,42]

--- a/src/status.rs
+++ b/src/status.rs
@@ -923,9 +923,23 @@ mod test {
 
     #[test]
     fn deserialize_status() {
-        let data = "{\"api\":\"0.13\",\"space\":\"a\",\"logo\":\"b\",\"url\":\"c\",\
-                    \"location\":{\"lat\":0.0,\"lon\":0.0},\"contact\":{},\"issue_report_channels\":[],\
-                    \"state\":{\"open\":null},\"ext_aaa\":\"xxx\",\"ext_bbb\":[null,42]}";
+        let data = r#"{
+            "api": "0.13",
+            "space": "a",
+            "logo": "b",
+            "url": "c",
+            "location": {
+                "lat": 0.0,
+                "lon": 0.0
+            },
+            "contact": {},
+            "issue_report_channels": [],
+            "state": {
+                "open": null
+            },
+            "ext_aaa": "xxx",
+            "ext_bbb": [null,42]
+        }"#;
         let deserialized: Status = from_str(data).unwrap();
         assert_eq!(deserialized.api, Some("0.13".into()));
         let keys = deserialized.extensions.keys();

--- a/src/status.rs
+++ b/src/status.rs
@@ -40,7 +40,7 @@ impl Spacefed {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 pub struct Icon {
     pub open: String,
-    pub close: String,
+    pub closed: String,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
The `state.icon` object contains two fields `open` and `closed`; the latter is typoed as `close` in this library, making deserialization fail.

I have used `#[serde(rename)]` for now to avoid a breaking change; the field itself should probably eventually be renamed to `closed`.

## Checklist

- [x] Tests added if applicable
- [ ] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
