### PR TITLE
Remove deprecated `Status::new` constructor method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ### Unreleased
 
 - [changed] Require at least Rust 1.75
+- [changed] Remove deprecated `Status::new` constructor method
 
 ### V0.9.0 (2023-05-07)
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -278,33 +278,6 @@ pub struct Status {
     pub extensions: Extensions,
 }
 
-impl Status {
-    /// Create a new Status object with only the absolutely required fields.
-    #[deprecated(
-        since = "0.5.0",
-        note = "Please use the `StatusBuilder` or a struct expression instead"
-    )]
-    pub fn new<S: Into<String>>(
-        space: S,
-        logo: S,
-        url: S,
-        location: Location,
-        contact: Contact,
-        issue_report_channels: Vec<IssueReportChannel>,
-    ) -> Status {
-        Status {
-            api: Some("0.13".into()),
-            space: space.into(),
-            logo: logo.into(),
-            url: url.into(),
-            location,
-            contact,
-            issue_report_channels,
-            ..Default::default()
-        }
-    }
-}
-
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 enum StatusBuilderVersion {
     #[default]


### PR DESCRIPTION
It has been deprecated for a few versions now and hinders the implementation of v15.

## Checklist

- [n/a] Tests added if applicable
- [n/a] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message